### PR TITLE
#100 add x86 arch to main containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM amd64/ubuntu:20.04
 
 LABEL maintainer="Reindert Vetter"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     #     networks:
     #         - confetti
     mysql:
-        image: 'mysql:8.0'
+        image: 'amd64/mysql:8.0'
         ports:
             - '${FORWARD_DB_PORT:-3306}:3306'
         environment:


### PR DESCRIPTION
Added amd64(x86) arch definition to containers to enable functionality on ARM CPUs as per issue #100 
