### PR TITLE
.env.example: update APP_HOST default value

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@ APP_ENV=development
 APP_PORT=80
 APP_KEY=
 APP_DEBUG=true
-APP_URL=http://localhost
+APP_HOST=127.0.0.1
 
 DB_CONNECTION=mysql
 DB_HOST=mysql


### PR DESCRIPTION
This patch fixes two things

- APP_URL was replaced with APP_HOST in April 2021

- uses 127.0.0.1 instead of localhost as example value. The reason is that both Windows and macOS firewalls will show pop-ups if listening on "localhost", but will not show any popups if listening on "127.0.0.1" - this is a better developer experience out of the box.