### PR TITLE
Ignore environment files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ main
 
 # Dependency directories
 vendor
+
+# Environment files
+.env*
+!.env.example


### PR DESCRIPTION
Files matching .env* should probably never be committed as they are
environment-specific and likely contain passwords. As people use this
repository as a template, this ignores environment files to prevent
accidental commits of them.