### PR TITLE
Fix provider path in comment

### DIFF
--- a/app/http/decorator/boot_providers.go
+++ b/app/http/decorator/boot_providers.go
@@ -7,7 +7,7 @@ import (
 
 type bootProviders struct{}
 
-// Bootstrap handles all bootProviders. Providers are located in config/providers/providers.go
+// Bootstrap handles all bootProviders. Providers are configured in app/providers/provider_index.go
 func (r bootProviders) Bootstrap(container inter.Container) inter.Container {
 	for _, bootstrapper := range providers.Providers.BootProviders {
 		container = bootstrapper.Boot(container)

--- a/app/http/decorator/register_providers.go
+++ b/app/http/decorator/register_providers.go
@@ -7,7 +7,7 @@ import (
 
 type registerProviders struct{}
 
-// Bootstrap handles all registerProviders. Providers are located in config/providers/providers.go
+// Bootstrap handles all registerProviders. Providers are configured in app/providers/provider_index.go
 func (r registerProviders) Bootstrap(container inter.Container) inter.Container {
 	for _, bootstrapper := range providers.Providers.RegisterProviders {
 		container = bootstrapper.Register(container)


### PR DESCRIPTION
This changes a comment that mentions a path where providers are
supposedly located. The path was wrong as providers are currently
configured in `app/providers/provider_index.go`.